### PR TITLE
Fix StudentGroup removal crashing on composite key

### DIFF
--- a/src/EduTrack.Data/IRepositories/IRepository.cs
+++ b/src/EduTrack.Data/IRepositories/IRepository.cs
@@ -11,6 +11,7 @@ namespace EduTrack.Data.IRepositories
     public interface IRepository<TEntity> where TEntity : Auditable
     {
         Task<bool> DeleteAsync(int id);
+        Task<bool> DeleteAsync(TEntity entity);
         IQueryable<TEntity> SelectAll();
         Task<TEntity> SelectByIdAsync(int id);
         Task<TEntity> SelectAsync(Expression<Func<TEntity, bool>> predicate);

--- a/src/EduTrack.Data/Repositories/Repository.cs
+++ b/src/EduTrack.Data/Repositories/Repository.cs
@@ -23,6 +23,13 @@ namespace EduTrack.Data.Repositories
             return true;
         }
 
+        public async Task<bool> DeleteAsync(TEntity entity)
+        {
+            dbSet.Remove(entity);
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
         public async Task<TEntity> InsertAsync(TEntity entity)
         {
             await dbSet.AddAsync(entity);

--- a/src/EduTrack.Service/Services/StudentGroupService.cs
+++ b/src/EduTrack.Service/Services/StudentGroupService.cs
@@ -70,7 +70,7 @@ public class StudentGroupService : IStudentGroupService
             sg => sg.StudentId == studentId && sg.GroupId == groupId)
             ?? throw new CustomException(404, "Bu o'quvchi bu guruhda ro'yxatda yo'q");
 
-        await _studentGroupRepository.DeleteAsync(studentGroup.Id);
+        await _studentGroupRepository.DeleteAsync(studentGroup);
         return true;
     }
 


### PR DESCRIPTION
## Summary
Follow-up to #15. After that PR merged, testing the live app surfaced a second bug in the same enrollment flow:

- `StudentGroup` uses a composite key (`StudentId`, `GroupId`) instead of a single `Id`.
- `RemoveStudentAsync` called the generic `Repository.DeleteAsync(int id)`, which does `dbSet.FindAsync(id)` — this throws `"Entity type 'StudentGroup' is defined with a 2-part composite key, but 1 values were passed to the 'Find' method"` for every remove/bulk-remove.
- Added a `DeleteAsync(TEntity entity)` overload to `IRepository<T>`/`Repository<T>` that removes the already-fetched entity directly, sidestepping the key-shape mismatch. `RemoveStudentAsync` now uses it.

## Test plan
- [x] `dotnet build` passes (0 errors)
- [x] Ran the app locally against LocalDB, replayed the exact browser fetch request for `/Enrollment/Remove` — confirmed 200 + `success:true`, and the student actually moved from "enrolled" to "available" on reload (not just a soft-delete flag left dangling)
- [x] Re-enrolled the same student afterward to confirm no lingering state/duplicate-key issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)